### PR TITLE
fix misspelling

### DIFF
--- a/config.json
+++ b/config.json
@@ -23,7 +23,7 @@
  "most_popular_tag": "big breasts",
  "awful_tags": [
     "rape",
-    "gure",
+    "guro",
     "scat",
     "torture",
     "moral degeneration",


### PR DESCRIPTION
the tag is actually 'guro', not 'gure' and yes, it's the most horrible tag of nhentai.